### PR TITLE
Enable removing code regions at will from a tracked Source

### DIFF
--- a/ext/vesper-cli/src/edu/ucsc/refactor/cli/Environment.java
+++ b/ext/vesper-cli/src/edu/ucsc/refactor/cli/Environment.java
@@ -240,7 +240,7 @@ public class Environment {
 
                 final boolean isOrigin = each.equals(getTrackedSource());
 
-                final Source to         = getCodeRefactorer().rewind(each);
+                final Source to         = getCodeRefactorer().regress(each);
                 final Source indexed    = getCodeRefactorer().rewriteHistory(to);
 
                 final boolean isUpdateNeeded = !each.equals(indexed);

--- a/ext/vesper-cli/src/edu/ucsc/refactor/cli/commands/RemoveRegionCommand.java
+++ b/ext/vesper-cli/src/edu/ucsc/refactor/cli/commands/RemoveRegionCommand.java
@@ -10,6 +10,6 @@ import io.airlift.airline.Command;
 @Command(name = "region", description = "Remove a specified source code range")
 public class RemoveRegionCommand extends RemoveCommand {
     @Override protected ChangeRequest createChangeRequest(SourceSelection selection) {
-        throw new UnsupportedOperationException("to be implemented");
+        return ChangeRequest.deleteRegion(selection);
     }
 }

--- a/ext/vesper-cli/src/edu/ucsc/refactor/cli/commands/ReplCommand.java
+++ b/ext/vesper-cli/src/edu/ucsc/refactor/cli/commands/ReplCommand.java
@@ -108,7 +108,7 @@ public class ReplCommand extends VesperCommand {
                 continue;
             }
 
-            if(line.equals("repl")){
+            if(line.equals("ivp")){
                 interpreter.print(Interpreter.VERSION + ", yeah! that's me.\n");
                 continue; // no need to call it again
             }

--- a/src/edu/ucsc/refactor/AbstractConfiguration.java
+++ b/src/edu/ucsc/refactor/AbstractConfiguration.java
@@ -80,6 +80,7 @@ public abstract class AbstractConfiguration implements Configuration {
         addSourceChanger(new RenameParam());
         addSourceChanger(new RenameField());
         addSourceChanger(new RenameClassOrInterface());
+        addSourceChanger(new RemoveCodeRegion());
 
         // credentials must be added here..
         addCredentials(null);

--- a/src/edu/ucsc/refactor/ChangeRequest.java
+++ b/src/edu/ucsc/refactor/ChangeRequest.java
@@ -101,7 +101,7 @@ public class ChangeRequest {
 
 
     /**
-     * Delete a class change request with selection.
+     * Delete a class change request given selection.
      *
      * @see {@link SingleEdit#deleteClass(SourceSelection)}
      */
@@ -113,7 +113,7 @@ public class ChangeRequest {
 
 
     /**
-     * Delete a method change request with selection.
+     * Delete a method change request given selection.
      *
      * @see {@link SingleEdit#deleteMethod(SourceSelection)}
      */
@@ -125,7 +125,7 @@ public class ChangeRequest {
 
 
     /**
-     * Delete a field change request with selection.
+     * Delete a field change request given selection.
      *
      * @see {@link SingleEdit#deleteField(SourceSelection)}
      */
@@ -137,13 +137,25 @@ public class ChangeRequest {
 
 
     /**
-     * Delete a parameter change request with selection.
+     * Delete a parameter change request given selection.
      *
      * @see {@link SingleEdit#deleteParameter(SourceSelection)}
      */
     public static ChangeRequest deleteParameter(SourceSelection selection){
         return ChangeRequest.forEdit(
                 SingleEdit.deleteParameter(selection)
+        );
+    }
+
+
+    /**
+     * Delete a code region change request given selection.
+     *
+     * @see {@link SingleEdit#deleteRegion(SourceSelection)}
+     */
+    public static ChangeRequest deleteRegion(SourceSelection selection){
+        return ChangeRequest.forEdit(
+                SingleEdit.deleteRegion(selection)
         );
     }
 

--- a/src/edu/ucsc/refactor/Refactorer.java
+++ b/src/edu/ucsc/refactor/Refactorer.java
@@ -12,6 +12,18 @@ import java.util.List;
  */
 public interface Refactorer {
     /**
+     * Re-does any {@link Refactorer#regress(Source) undo-ed} changes made by the
+     * {@code Refactorer}.
+     *
+     * @param current The current Source.
+     * @return The {@code Source}'s next version, after the advance. Or the
+     *      same {@code current} if {@code current} is the only
+     *      available version of {@code Source}.
+     * @throws java.lang.NullPointerException if {@code Source} null.
+     */
+    Source advance(Source current);
+
+    /**
      * Applies a code change to a {@code Source} and then returns a {@link CommitRequest}, which
      * represents a set of applied changes, or "deltas", from one version of the {@code Source} to
      * the next.
@@ -60,16 +72,6 @@ public interface Refactorer {
      * @throws java.lang.NullPointerException if {@code Source} null.
      */
     void detectIssues(Source code);
-
-    /**
-     * Re-does any {@link Refactorer#rewind(Source) undo-ed} changes made by the
-     * {@code Refactorer}.
-     *
-     * @param current The current Source.
-     * @return The Source, after the forward
-     * @throws java.lang.NullPointerException if {@code Source} null.
-     */
-    Source forward(Source current);
 
     /**
      * Returns the list of {@code Source}s  tracked by this {@code Refactorer}.
@@ -164,8 +166,8 @@ public interface Refactorer {
      * </p>
      *
      * @param source THe current Source. This Source can be the same as the indexed Source, or
-     *    a Source product of the methods {@link Refactorer#rewind(Source)} or
-     *    {@link Refactorer#forward(Source)}.
+     *    a Source product of the methods {@link Refactorer#regress(Source)} or
+     *    {@link Refactorer#advance(Source)}.
      *
      * @return the indexed Source, after the rewrite.
      * @throws java.lang.NullPointerException if {@code Source} null.
@@ -177,8 +179,10 @@ public interface Refactorer {
      * Un-does the changes made by the {@code Refactorer}.
      *
      * @param current The current Source.
-     * @return The Source, after the rewind
+     * @return The {@code Source}'s previous version, after the regress. Or the
+     *      same {@code current} if {@code current} is the only
+     *      available version of {@code Source}.
      * @throws java.lang.NullPointerException if {@code Source} null.
      */
-    Source rewind(Source current);
+    Source regress(Source current);
 }

--- a/src/edu/ucsc/refactor/SingleEdit.java
+++ b/src/edu/ucsc/refactor/SingleEdit.java
@@ -81,6 +81,17 @@ public class SingleEdit extends AbstractCauseOfChange {
         return new SingleEdit(Refactoring.DELETE_PARAMETER, selection);
     }
 
+
+    /**
+     * Deletes a code region, which location can be inferred from {@code SourceSelection}
+     *
+     * @param selection The selected region
+     * @return The {@code SingleEdit}.
+     */
+    public static SingleEdit deleteRegion(SourceSelection selection){
+        return new SingleEdit(Refactoring.DELETE_REGION, selection);
+    }
+
     /**
      * Optimizes the import declarations found in a {@code Source} code.
      *

--- a/src/edu/ucsc/refactor/internal/JavaRefactorer.java
+++ b/src/edu/ucsc/refactor/internal/JavaRefactorer.java
@@ -167,7 +167,6 @@ public class JavaRefactorer implements Refactorer {
         }
     }
 
-    // forward
     @Override public Source rewriteHistory(Source source) {
 
         final Source        from   = Preconditions.checkNotNull(source);
@@ -226,7 +225,7 @@ public class JavaRefactorer implements Refactorer {
         return from;
     }
 
-    @Override public Source forward(Source current) {
+    @Override public Source advance(Source current) {
         final CommitHistory history = getCommitHistory(current);
 
         for(Checkpoint each : history){
@@ -235,11 +234,11 @@ public class JavaRefactorer implements Refactorer {
             }
         }
 
-        // otherwise, there is nothing to forward (i.e., current is the latest version)
+        // otherwise, there is nothing to advance (i.e., current is the latest version)
         return current;
     }
 
-    @Override public Source rewind(Source current) {
+    @Override public Source regress(Source current) {
         final CommitHistory history = getCommitHistory(current);
 
         for(Checkpoint each : history){

--- a/src/edu/ucsc/refactor/internal/JavaRefactorer.java
+++ b/src/edu/ucsc/refactor/internal/JavaRefactorer.java
@@ -6,9 +6,11 @@ import com.google.common.collect.Maps;
 import edu.ucsc.refactor.*;
 import edu.ucsc.refactor.internal.visitors.MethodDeclarationVisitor;
 import edu.ucsc.refactor.internal.visitors.SelectedASTNodeVisitor;
+import edu.ucsc.refactor.internal.visitors.SelectedStatementNodesVisitor;
 import edu.ucsc.refactor.spi.*;
 import edu.ucsc.refactor.util.CommitHistory;
 import edu.ucsc.refactor.util.Checkpoint;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 
@@ -122,30 +124,46 @@ public class JavaRefactorer implements Refactorer {
 
         getValidContexts().put(code, context);
 
-        final SelectedASTNodeVisitor visitor = new SelectedASTNodeVisitor(select.toLocation());
-        context.accept(visitor);
 
-        // it blows up with we want to reformat a CompilationUnit, since
-        // StructuralPropertyDescriptor in ASTRewrite. Therefore, here is a
-        // HACK that solves the issue: A compilation unit is the same as formatting all
-        // constructors and method declarations..
-        if((visitor.getMatchedNode() instanceof CompilationUnit)
-                || visitor.getMatchedNode() == null){
+        if(cause.getName().isSame(Refactoring.DELETE_REGION)){
+            final SelectedStatementNodesVisitor statements = new SelectedStatementNodesVisitor(select.toLocation(), true);
+            context.accept(statements);
+            statements.checkIfSelectionCoversValidStatements();
 
-            if(cause.getName().isSame(Refactoring.DELETE_UNUSED_IMPORTS)){
-                edit.addNode(context.getCompilationUnit());
-            } else {
-                final MethodDeclarationVisitor methods = new MethodDeclarationVisitor();
-                methods.includeConstructor(true);
-                context.accept(methods);
-                for(MethodDeclaration each : methods.getMethodDeclarations()){
+            if(statements.isSelectionCoveringValidStatements()){
+                for(ASTNode each : statements.getSelectedNodes()){
                     edit.addNode(each);
                 }
             }
 
-        } else {
-            edit.addNode(visitor.getMatchedNode());
+        }  else {
+            final SelectedASTNodeVisitor visitor = new SelectedASTNodeVisitor(select.toLocation());
+            context.accept(visitor);
+
+            // it blows up with we want to reformat a CompilationUnit, since
+            // StructuralPropertyDescriptor in ASTRewrite. Therefore, here is a
+            // HACK that solves the issue: A compilation unit is the same as formatting all
+            // constructors and method declarations..
+            if((visitor.getMatchedNode() instanceof CompilationUnit)
+                    || visitor.getMatchedNode() == null){
+
+                if(cause.getName().isSame(Refactoring.DELETE_UNUSED_IMPORTS)){
+                    edit.addNode(context.getCompilationUnit());
+                } else {
+                    final MethodDeclarationVisitor methods = new MethodDeclarationVisitor();
+                    methods.includeConstructor(true);
+                    context.accept(methods);
+                    for(MethodDeclaration each : methods.getMethodDeclarations()){
+                        edit.addNode(each);
+                    }
+                }
+
+            } else {
+                edit.addNode(visitor.getMatchedNode());
+            }
         }
+
+
 
         return edit;
     }

--- a/src/edu/ucsc/refactor/internal/changers/RemoveCodeRegion.java
+++ b/src/edu/ucsc/refactor/internal/changers/RemoveCodeRegion.java
@@ -1,0 +1,53 @@
+package edu.ucsc.refactor.internal.changers;
+
+import com.google.common.base.Preconditions;
+import edu.ucsc.refactor.CauseOfChange;
+import edu.ucsc.refactor.Change;
+import edu.ucsc.refactor.Parameter;
+import edu.ucsc.refactor.internal.Delta;
+import edu.ucsc.refactor.internal.SourceChange;
+import edu.ucsc.refactor.spi.Refactoring;
+import edu.ucsc.refactor.spi.SourceChanger;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
+import java.util.Map;
+
+/**
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class RemoveCodeRegion extends SourceChanger {
+    @Override public boolean canHandle(CauseOfChange cause) {
+        return cause.getName().isSame(Refactoring.DELETE_REGION);
+    }
+
+    @Override protected Change initChanger(CauseOfChange cause, Map<String, Parameter> parameters) {
+        final SourceChange change = new SourceChange(cause, this, parameters);
+
+        try {
+
+            Preconditions.checkState(!cause.getAffectedNodes().isEmpty(), "invalid code selection");
+
+            final CompilationUnit   root      = getCompilationUnit(cause);
+            final ASTRewrite        rewrite   = ASTRewrite.create(root.getAST());
+
+            change.getDeltas().add(removeCodeRegion(root, rewrite, cause));
+
+        } catch (Throwable ex){
+            change.getErrors().add(ex.getMessage());
+        }
+
+        return change;
+    }
+
+
+    private Delta removeCodeRegion(CompilationUnit unit, ASTRewrite rewrite, CauseOfChange cause){
+
+        for(ASTNode each : cause.getAffectedNodes()){
+            rewrite.remove(each, null);
+        }
+
+        return createDelta(unit, rewrite);
+    }
+}

--- a/src/edu/ucsc/refactor/internal/util/AstUtil.java
+++ b/src/edu/ucsc/refactor/internal/util/AstUtil.java
@@ -2,6 +2,7 @@ package edu.ucsc.refactor.internal.util;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import edu.ucsc.refactor.Location;
 import edu.ucsc.refactor.Source;
@@ -14,6 +15,7 @@ import org.eclipse.jdt.core.dom.*;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -189,6 +191,19 @@ public class AstUtil {
 
         // Is the method at the same position as the other node?
         return (Locations.bothSame(nodeLocation, selection));
+    }
+
+    public static List<ASTNode> getSwitchCases(SwitchStatement node) {
+        final List<ASTNode> result = Lists.newArrayList();
+        for (Object element : node.statements()) {
+            if (element instanceof SwitchCase) {
+                final ASTNode each = (ASTNode) element;
+                final SwitchCase switchCase = exactCast(SwitchCase.class, each);
+                result.add(switchCase);
+
+            }
+        }
+        return result;
     }
 
 

--- a/src/edu/ucsc/refactor/internal/visitors/SelectedASTNodesVisitor.java
+++ b/src/edu/ucsc/refactor/internal/visitors/SelectedASTNodesVisitor.java
@@ -125,9 +125,9 @@ public abstract class SelectedASTNodesVisitor extends SourceVisitor {
     @Override protected boolean visitNode(ASTNode node) {
         final Location nodeLocation = Locations.locate(node);
 
-        if(Locations.liesOutside(selectedArea, nodeLocation)) return false;
-
-        if(Locations.covers(selectedArea, nodeLocation)) {
+        if(Locations.liesOutside(selectedArea, nodeLocation)) {
+            return false;
+        } else if(Locations.covers(selectedArea, nodeLocation)) {
             if (isFirstNode()) {
                 handleFirstSelectedNode(node);
             } else {
@@ -135,9 +135,7 @@ public abstract class SelectedASTNodesVisitor extends SourceVisitor {
             }
 
             return traverseSelectedNode;
-        }
-
-        if(Locations.coveredBy(selectedArea, nodeLocation)){
+        } else if(Locations.coveredBy(selectedArea, nodeLocation)){
             lastCoveringNode = node;
             return true;
         } else if(Locations.endsIn(selectedArea, nodeLocation)){

--- a/src/edu/ucsc/refactor/internal/visitors/SelectedASTNodesVisitor.java
+++ b/src/edu/ucsc/refactor/internal/visitors/SelectedASTNodesVisitor.java
@@ -1,0 +1,176 @@
+package edu.ucsc.refactor.internal.visitors;
+
+import com.google.common.base.Preconditions;
+import edu.ucsc.refactor.Location;
+import edu.ucsc.refactor.Source;
+import edu.ucsc.refactor.internal.SourceLocation;
+import edu.ucsc.refactor.internal.SourceVisitor;
+import edu.ucsc.refactor.util.Locations;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Expression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public abstract class SelectedASTNodesVisitor extends SourceVisitor {
+    private final Location      selectedArea;
+    private final boolean       traverseSelectedNode;
+    private final List<ASTNode> selectedNodes;
+
+    private ASTNode lastCoveringNode;
+
+
+    /**
+     * Instantiates a new {@link SelectedASTNodesVisitor} object.
+     *
+     * @param selectedArea The selected area.
+     * @param traverseSelectedNode {@code true} if selected node
+     *             should be traversed, {@code false} otherwise.
+     */
+    public SelectedASTNodesVisitor(Location selectedArea, boolean traverseSelectedNode){
+        super(true);
+        this.selectedArea           = selectedArea;
+        this.traverseSelectedNode   = traverseSelectedNode;
+        this.selectedNodes          = new ArrayList<ASTNode>();
+    }
+
+
+    public abstract boolean checkIfSelectionCoversValidStatements();
+
+
+    /**
+     * @return {@code true} if the selected area by user
+     *      has mapped into covered AST nodes, {@code false} otherwise.
+     */
+    public boolean hasSelectedNodes() {
+        return !selectedNodes.isEmpty();
+    }
+
+    /**
+     * @return the list of AST nodes covered by
+     *      selected area, empty list if none selected..
+     */
+    public List<ASTNode> getSelectedNodes() {
+        return selectedNodes;
+    }
+
+    /**
+     *
+     * @return
+     */
+    public ASTNode getFirstSelectedNode() {
+        if (!hasSelectedNodes()) return null;
+        return selectedNodes.get(0);
+    }
+
+    /**
+     *
+     * @return
+     */
+    public ASTNode getLastSelectedNode() {
+        if (!hasSelectedNodes()) return null;
+        return selectedNodes.get(selectedNodes.size() - 1);
+    }
+
+    /**
+     *
+     * @return
+     */
+    public boolean isExpressionSelected() {
+        return hasSelectedNodes()
+                && getFirstSelectedNode() instanceof Expression;
+    }
+
+    /**
+     *
+     * @return
+     */
+    protected Location getSelection() {
+        return selectedArea;
+    }
+
+    /**
+     * @return The last covering node by user selected area.
+     */
+    public ASTNode getLastCoveringNode() {
+        return lastCoveringNode;
+    }
+
+    /**
+     * @return The range, in location form, of all selected nodes.
+     */
+    public Location getSelectedNodeRange() {
+        if (!hasSelectedNodes()) return null;
+
+
+        final ASTNode   firstNode   = getFirstSelectedNode();
+        final ASTNode   lastNode    = getLastSelectedNode();
+        final int       start       = firstNode.getStartPosition();
+        final Source    code        = selectedArea.getSource();
+
+        return SourceLocation.createLocation(
+                code,
+                code.getContents(),
+                start,
+                lastNode.getStartPosition() + lastNode.getLength() - start
+        );
+    }
+
+    public abstract boolean isSelectionCoveringValidStatements();
+
+
+    @Override protected boolean visitNode(ASTNode node) {
+        final Location nodeLocation = Locations.locate(node);
+
+        if(Locations.liesOutside(selectedArea, nodeLocation)) return false;
+
+        if(Locations.covers(selectedArea, nodeLocation)) {
+            if (isFirstNode()) {
+                handleFirstSelectedNode(node);
+            } else {
+                handleNextSelectedNode(node);
+            }
+
+            return traverseSelectedNode;
+        }
+
+        if(Locations.coveredBy(selectedArea, nodeLocation)){
+            lastCoveringNode = node;
+            return true;
+        } else if(Locations.endsIn(selectedArea, nodeLocation)){
+            return handleSelectionEndsIn(node);
+        }
+
+        return true;
+    }
+
+    /**
+     * @return {@code true} if we have selected any node, and the one
+     *      we are exploring is the first one to check.
+     */
+    private boolean isFirstNode() {
+        return !hasSelectedNodes();
+    }
+
+
+    protected void handleFirstSelectedNode(ASTNode node) {
+        selectedNodes.clear();
+        selectedNodes.add(node);
+    }
+
+
+    protected void handleNextSelectedNode(ASTNode node) {
+        if (getFirstSelectedNode().getParent() == node.getParent()) {
+            selectedNodes.add(node);
+        }
+    }
+
+
+    protected boolean handleSelectionEndsIn(ASTNode node) {
+        Preconditions.checkNotNull(node);
+        return false;
+    }
+}

--- a/src/edu/ucsc/refactor/internal/visitors/SelectedASTNodesVisitor.java
+++ b/src/edu/ucsc/refactor/internal/visitors/SelectedASTNodesVisitor.java
@@ -58,8 +58,7 @@ public abstract class SelectedASTNodesVisitor extends SourceVisitor {
     }
 
     /**
-     *
-     * @return
+     * @return The first selected ASTNode.
      */
     public ASTNode getFirstSelectedNode() {
         if (!hasSelectedNodes()) return null;
@@ -67,8 +66,7 @@ public abstract class SelectedASTNodesVisitor extends SourceVisitor {
     }
 
     /**
-     *
-     * @return
+     * @return The last selected ASTNode.
      */
     public ASTNode getLastSelectedNode() {
         if (!hasSelectedNodes()) return null;
@@ -76,8 +74,7 @@ public abstract class SelectedASTNodesVisitor extends SourceVisitor {
     }
 
     /**
-     *
-     * @return
+     * @return {@code true} if the first selected node is an {@code Expression}.
      */
     public boolean isExpressionSelected() {
         return hasSelectedNodes()
@@ -85,8 +82,7 @@ public abstract class SelectedASTNodesVisitor extends SourceVisitor {
     }
 
     /**
-     *
-     * @return
+     * @return The Location mapping to a code selection.
      */
     protected Location getSelection() {
         return selectedArea;

--- a/src/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitor.java
+++ b/src/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitor.java
@@ -38,8 +38,14 @@ public class SelectedStatementNodesVisitor extends SelectedASTNodesVisitor {
         final Location selection  = getSelection();
 
 
-        invalidSelection(Locations.intersects(firstNode, selection)
+        final boolean isIntersecting = (Locations.intersects(firstNode, selection)
                 || Locations.intersects(secondNode, selection));
+
+        final boolean isNotInside    = !(Locations.begins(selection, firstNode.getStart())
+                && Locations.ends(selection, secondNode.getEnd()));
+
+
+        invalidSelection(isIntersecting && isNotInside);
 
         if(isSelectionCoveringValidStatements()){
             if (firstNode instanceof ArrayInitializer) {

--- a/src/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitor.java
+++ b/src/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitor.java
@@ -1,0 +1,200 @@
+package edu.ucsc.refactor.internal.visitors;
+
+import edu.ucsc.refactor.Location;
+import edu.ucsc.refactor.internal.util.AstUtil;
+import edu.ucsc.refactor.util.Locations;
+import org.eclipse.jdt.core.dom.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class SelectedStatementNodesVisitor extends SelectedASTNodesVisitor {
+
+    private final AtomicBoolean invalidSelection;
+
+    /**
+     * Instantiates a new {@code SelectedStatementNodesVisitor} with a given code selection and
+     * a traversal flag as values.
+     *
+     * @param selection The code selected by user, in a location form.
+     * @param traverseSelectedNode {@code true} if the selected node should be traversed,
+     *    {@code false} otherwise.
+     */
+    public SelectedStatementNodesVisitor(Location selection, boolean traverseSelectedNode){
+        super(selection, traverseSelectedNode);
+        this.invalidSelection = new AtomicBoolean(false);
+    }
+
+    @Override public boolean checkIfSelectionCoversValidStatements(){
+        final List<ASTNode> nodes = getSelectedNodes();
+
+        if(nodes.isEmpty()) return false;
+
+        final Location firstNode  = Locations.locate(getFirstSelectedNode());
+        final Location secondNode = Locations.locate(getLastSelectedNode());
+        final Location selection  = getSelection();
+
+
+        invalidSelection(Locations.intersects(firstNode, selection)
+                || Locations.intersects(secondNode, selection));
+
+        if(isSelectionCoveringValidStatements()){
+            if (firstNode instanceof ArrayInitializer) {
+                invalidSelection(true);
+            }
+        }
+
+        return isSelectionCoveringValidStatements();
+    }
+
+
+    @Override public boolean isSelectionCoveringValidStatements(){
+        return !this.invalidSelection.get();
+    }
+
+
+    private void invalidSelection(boolean value){
+        this.invalidSelection.compareAndSet(this.invalidSelection.get(), value);
+    }
+
+
+    @Override public void endVisit(CompilationUnit node) {
+        if(!hasSelectedNodes()){
+            super.endVisit(node);
+            return;
+        }
+
+        if(isSelectionCoveringValidStatements()){
+            checkIfSelectionCoversValidStatements();
+        }
+
+        super.endVisit(node);
+    }
+
+
+    @Override public void endVisit(DoStatement node) {
+        if (doAfterValidation(node, getSelectedNodes())) {
+            if (contains(getSelectedNodes(), node.getBody())
+                    && contains(getSelectedNodes(), node.getExpression())) {
+
+                invalidSelection(true);
+
+            }
+        }
+
+        super.endVisit(node);
+    }
+
+    @Override public void endVisit(ForStatement node) {
+        if (doAfterValidation(node, getSelectedNodes())) {
+            boolean containsExpression= contains(getSelectedNodes(), node.getExpression());
+            boolean containsUpdaters= contains(getSelectedNodes(), node.updaters());
+
+            if (contains(getSelectedNodes(), node.initializers()) && containsExpression) {
+                invalidSelection(true);
+            } else if (containsExpression && containsUpdaters) {
+                invalidSelection(true);
+            } else if (containsUpdaters && contains(getSelectedNodes(), node.getBody())) {
+                invalidSelection(true);
+            }
+
+        }
+        super.endVisit(node);
+    }
+
+
+    @Override public void endVisit(SwitchStatement node) {
+        if (doAfterValidation(node, getSelectedNodes())) {
+            List<ASTNode> cases = AstUtil.getSwitchCases(node);
+            for(ASTNode eachSelected : getSelectedNodes()){
+                if(cases.contains(eachSelected)){
+                    invalidSelection(true);
+                    break;
+                }
+            }
+        }
+        super.endVisit(node);
+    }
+
+
+    @Override public void endVisit(SynchronizedStatement node) {
+        final ASTNode  firstNode    = getFirstSelectedNode();
+        final Location nodeLocation = Locations.locate(firstNode);
+
+        if(Locations.covers(getSelection(), nodeLocation)){
+            if(firstNode == node.getBody()){
+                invalidSelection(true);
+            }
+        }
+
+        super.endVisit(node);
+
+    }
+
+
+    @Override public void endVisit(TryStatement node) {
+        final ASTNode  firstNode    = getFirstSelectedNode();
+        final Location nodeLocation = Locations.locate(firstNode);
+
+        if(Locations.isAfterBaseLocation(getSelection(), nodeLocation)){
+           if(firstNode == node.getBody() || firstNode == node.getFinally()){
+               invalidSelection(true);
+           } else {
+               final List catchClauses = node.catchClauses();
+               for(Object eachCatch : catchClauses){
+                   final CatchClause element = (CatchClause) eachCatch;
+                   if (element == firstNode || element.getBody() == firstNode) {
+                       invalidSelection(true);
+                   } else if(element.getException() == firstNode){
+                       invalidSelection(true);
+                   }
+               }
+           }
+        }
+
+        super.endVisit(node);
+    }
+
+
+    @Override public void endVisit(WhileStatement node) {
+        if(doAfterValidation(node, getSelectedNodes())){
+            if (contains(getSelectedNodes(), node.getExpression())
+                    && contains(getSelectedNodes(), node.getBody())) {
+
+                invalidSelection(true);
+            }
+        }
+
+        super.endVisit(node);
+    }
+
+
+    private boolean doAfterValidation(ASTNode node, List<ASTNode> selectedNodes) {
+        final Location nodeLocation = Locations.locate(node);
+        final Location base         = getSelection();
+        return (selectedNodes.size() > 0
+                && node == selectedNodes.get(0).getParent()
+                && Locations.isAfterBaseLocation(base, nodeLocation));
+    }
+
+
+
+    protected static boolean contains(List<ASTNode> nodes, ASTNode node) {
+        for (ASTNode each : nodes) {
+            if (each == node) return true;
+        }
+
+        return false;
+    }
+
+    protected static boolean contains(List<ASTNode> nodes, List list) {
+        for (ASTNode node : nodes) {
+            if (list.contains(node)) return true;
+        }
+
+        return false;
+    }
+}

--- a/src/edu/ucsc/refactor/util/Locations.java
+++ b/src/edu/ucsc/refactor/util/Locations.java
@@ -162,12 +162,25 @@ public class Locations {
      * @param position The other node's start position.
      * @return {@code true} if this node's location (base) covers a node at given start position.
      */
-    public static boolean matches(Location base, Position position){
+    public static boolean begins(Location base, Position position/*start position*/){
         final Position start    = base.getStart();
+
+        return start.getOffset() <= position.getOffset();
+
+    }
+
+
+    /**
+     * Returns {@code true} if this node's location covers a node at given start position.
+     *
+     * @param base The base location.
+     * @param position The other node's start position.
+     * @return {@code true} if this node's location (base) covers a node at given start position.
+     */
+    public static boolean ends(Location base, Position position/*end position*/){
         final Position end      = base.getEnd();
 
-        return start.getOffset() <= position.getOffset()
-                && position.getOffset() < end.getOffset();
+        return end.getOffset() <= position.getOffset();
 
     }
 

--- a/test/edu/ucsc/refactor/internal/InternalTestSuite.java
+++ b/test/edu/ucsc/refactor/internal/InternalTestSuite.java
@@ -3,6 +3,8 @@ package edu.ucsc.refactor.internal;
 import edu.ucsc.refactor.internal.changers.ChangersTest;
 import edu.ucsc.refactor.internal.detectors.DetectorsTest;
 import edu.ucsc.refactor.internal.util.ASTUtilTest;
+import edu.ucsc.refactor.internal.visitors.SelectedASTNodeVisitorTest;
+import edu.ucsc.refactor.internal.visitors.SelectedStatementNodesVisitorTest;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.junit.runner.RunWith;
@@ -15,7 +17,9 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
         DetectorsTest.class,
         ChangersTest.class,
-        ASTUtilTest.class
+        ASTUtilTest.class,
+        SelectedASTNodeVisitorTest.class,
+        SelectedStatementNodesVisitorTest.class
 })
 public class InternalTestSuite {
     public static Test suite() {

--- a/test/edu/ucsc/refactor/internal/InternalUtil.java
+++ b/test/edu/ucsc/refactor/internal/InternalUtil.java
@@ -15,7 +15,7 @@ public class InternalUtil {
         return Locations.locateWord(code, word).get(0);
     }
 
-    public static Source createGenerealSource(){
+    public static Source createGeneralSource(){
         final String content = "import java.util.List; \n"
                 + "import java.util.Collection; \n"
                 + "class Name {\n"

--- a/test/edu/ucsc/refactor/internal/changers/ChangersTest.java
+++ b/test/edu/ucsc/refactor/internal/changers/ChangersTest.java
@@ -89,7 +89,7 @@ public class ChangersTest {
 
 
     @Test public void testChangerForOptimizeImports() throws Exception {
-        final Source  code    = InternalUtil.createGenerealSource();
+        final Source  code    = InternalUtil.createGeneralSource();
         final Context context = new Context(code);
 
         parser.parseJava(context);

--- a/test/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitorTest.java
+++ b/test/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitorTest.java
@@ -35,7 +35,7 @@ public class SelectedStatementNodesVisitorTest {
 
         final Location name = InternalUtil.locateWord(code, "Name");
 
-        final Location invalid = SourceLocation.createLocation(name.getSource(), name.getSource().getContents(), 6, 12);
+        final Location invalid = SourceLocation.createLocation(name.getSource(), name.getSource().getContents(), 6, 89);
 
         final SelectedStatementNodesVisitor statements = new SelectedStatementNodesVisitor(invalid, true);
         context.accept(statements);
@@ -116,6 +116,24 @@ public class SelectedStatementNodesVisitorTest {
 
         assertThat(statements.isSelectionCoveringValidStatements(), is(false));
 
+    }
+
+
+    @Test public void testExpansiveSelection(){
+        final Source code    = InternalUtil.createGeneralSource();
+        final Context context = new Context(code);
+
+        parser.parseJava(context);
+
+
+        final Location userSelection = SourceLocation.createLocation(code, code.getContents(), 88, 281);
+
+        final SelectedStatementNodesVisitor statements = new SelectedStatementNodesVisitor(userSelection, true);
+        context.accept(statements);
+        statements.checkIfSelectionCoversValidStatements();
+
+        assertThat(statements.getSelectedNodes().isEmpty(), is(false));
+        assertThat(statements.isSelectionCoveringValidStatements(), is(true));
     }
 
 

--- a/test/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitorTest.java
+++ b/test/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitorTest.java
@@ -3,16 +3,18 @@ package edu.ucsc.refactor.internal.visitors;
 import edu.ucsc.refactor.Context;
 import edu.ucsc.refactor.Location;
 import edu.ucsc.refactor.Source;
-import edu.ucsc.refactor.SourceSelection;
 import edu.ucsc.refactor.internal.EclipseJavaParser;
 import edu.ucsc.refactor.internal.InternalUtil;
 import edu.ucsc.refactor.internal.SourceLocation;
 import edu.ucsc.refactor.spi.JavaParser;
+import edu.ucsc.refactor.util.Locations;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -32,7 +34,6 @@ public class SelectedStatementNodesVisitorTest {
         parser.parseJava(context);
 
         final Location name = InternalUtil.locateWord(code, "Name");
-        context.setScope(new SourceSelection(name));
 
         final Location invalid = SourceLocation.createLocation(name.getSource(), name.getSource().getContents(), 6, 12);
 
@@ -50,7 +51,6 @@ public class SelectedStatementNodesVisitorTest {
         parser.parseJava(context);
 
         final Location name = InternalUtil.locateWord(code, "Name");
-        context.setScope(new SourceSelection(name));
 
         final SelectedStatementNodesVisitor statements = new SelectedStatementNodesVisitor(name, true);
         context.accept(statements);
@@ -58,6 +58,66 @@ public class SelectedStatementNodesVisitorTest {
 
         assertThat(statements.isSelectionCoveringValidStatements(), is(true));
     }
+
+
+    @Test public void testValidWholeMethodSelection(){
+        final Source code    = InternalUtil.createSourceWithMagicNumber();
+        final Context context = new Context(code);
+
+        parser.parseJava(context);
+
+        final Location boom = InternalUtil.locateWord(code, "boom");
+
+        final SelectedASTNodeVisitor visitor = new SelectedASTNodeVisitor(boom);
+        context.accept(visitor);
+
+        final ASTNode boomNode =  visitor.getMatchedNode();
+
+        assertNotNull(boomNode);
+
+        final Location boomLocation = Locations.locate(boomNode);
+
+        final SelectedStatementNodesVisitor statements = new SelectedStatementNodesVisitor(boomLocation, true);
+        context.accept(statements);
+        statements.checkIfSelectionCoversValidStatements();
+
+        assertThat(statements.isSelectionCoveringValidStatements(), is(true));
+
+    }
+
+
+    @Test public void testInvalidWholeMethodSelection(){
+        final Source code    = InternalUtil.createSourceWithMagicNumber();
+        final Context context = new Context(code);
+
+        parser.parseJava(context);
+
+        final Location boom = InternalUtil.locateWord(code, "boom");
+
+        final SelectedASTNodeVisitor visitor = new SelectedASTNodeVisitor(boom);
+        context.accept(visitor);
+
+        final ASTNode boomNode =  visitor.getMatchedNode();
+
+        assertNotNull(boomNode);
+
+        final Location boomLocation = Locations.locate(boomNode);
+
+        final Location invalid = SourceLocation.createLocation(
+                boomLocation.getSource(),
+                boomLocation.getSource().getContents(),
+                6, /*starts at N*/
+                boomLocation.getEnd().getOffset()
+        );
+
+        final SelectedStatementNodesVisitor statements = new SelectedStatementNodesVisitor(invalid, true);
+        context.accept(statements);
+        statements.checkIfSelectionCoversValidStatements();
+
+        assertThat(statements.isSelectionCoveringValidStatements(), is(false));
+
+    }
+
 
     @After public void tearDown() throws Exception {
         parser  = null;

--- a/test/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitorTest.java
+++ b/test/edu/ucsc/refactor/internal/visitors/SelectedStatementNodesVisitorTest.java
@@ -1,0 +1,65 @@
+package edu.ucsc.refactor.internal.visitors;
+
+import edu.ucsc.refactor.Context;
+import edu.ucsc.refactor.Location;
+import edu.ucsc.refactor.Source;
+import edu.ucsc.refactor.SourceSelection;
+import edu.ucsc.refactor.internal.EclipseJavaParser;
+import edu.ucsc.refactor.internal.InternalUtil;
+import edu.ucsc.refactor.internal.SourceLocation;
+import edu.ucsc.refactor.spi.JavaParser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class SelectedStatementNodesVisitorTest {
+    private JavaParser parser;
+
+    @Before public void setUp() throws Exception {
+        parser  = new EclipseJavaParser();
+    }
+
+    @Test public void testInvalidStatementsSelection(){
+        final Source    code    = InternalUtil.createSourceWithMagicNumber();
+        final Context   context = new Context(code);
+
+        parser.parseJava(context);
+
+        final Location name = InternalUtil.locateWord(code, "Name");
+        context.setScope(new SourceSelection(name));
+
+        final Location invalid = SourceLocation.createLocation(name.getSource(), name.getSource().getContents(), 6, 12);
+
+        final SelectedStatementNodesVisitor statements = new SelectedStatementNodesVisitor(invalid, true);
+        context.accept(statements);
+        statements.checkIfSelectionCoversValidStatements();
+
+        assertThat(statements.isSelectionCoveringValidStatements(), is(false));
+    }
+
+    @Test public void testValidStatementsSelection(){
+        final Source code    = InternalUtil.createSourceWithMagicNumber();
+        final Context context = new Context(code);
+
+        parser.parseJava(context);
+
+        final Location name = InternalUtil.locateWord(code, "Name");
+        context.setScope(new SourceSelection(name));
+
+        final SelectedStatementNodesVisitor statements = new SelectedStatementNodesVisitor(name, true);
+        context.accept(statements);
+        statements.checkIfSelectionCoversValidStatements();
+
+        assertThat(statements.isSelectionCoveringValidStatements(), is(true));
+    }
+
+    @After public void tearDown() throws Exception {
+        parser  = null;
+    }
+}

--- a/test/edu/ucsc/refactor/util/LocationsTest.java
+++ b/test/edu/ucsc/refactor/util/LocationsTest.java
@@ -50,6 +50,13 @@ public class LocationsTest {
         final Location b = SourceLocation.createLocation(SOURCE, CONTENT, 22, 67);
 
         assertThat(Locations.intersects(a, b), is(true));
+
+        final Location c = SourceLocation.createLocation(SOURCE, CONTENT, 0, 30);
+        final Location d = SourceLocation.createLocation(SOURCE, CONTENT, 0, 5);
+
+        assertThat(Locations.intersects(d, c), is(true));
+        assertThat(Locations.begins(c, d.getStart()), is(true));
+        assertThat(Locations.ends(c, d.getEnd()), is(false));
     }
 
     @Test public void testLocationsOneEndsInTheOther(){


### PR DESCRIPTION
Enable removing code regions at will; reporting an invalid selection if the selected statements are not covering one or more ASTNodes in an AST.
