### PR TITLE
Detect duplicate code

### DIFF
--- a/ext/vesper-cli/src/edu/ucsc/refactor/cli/Grammar.java
+++ b/ext/vesper-cli/src/edu/ucsc/refactor/cli/Grammar.java
@@ -26,6 +26,7 @@ public class Grammar {
                 .withCommand(OriginShow.class)
                 .withCommand(PublishCommand.class)
                 .withCommand(FormatCommand.class)
+                .withCommand(DeduplicateCommand.class)
                 .withCommand(OptimizeImportsCommand.class);
 
         builder.withGroup("whereis")

--- a/ext/vesper-cli/src/edu/ucsc/refactor/cli/commands/DeduplicateCommand.java
+++ b/ext/vesper-cli/src/edu/ucsc/refactor/cli/commands/DeduplicateCommand.java
@@ -1,0 +1,43 @@
+package edu.ucsc.refactor.cli.commands;
+
+import edu.ucsc.refactor.ChangeRequest;
+import edu.ucsc.refactor.Issue;
+import edu.ucsc.refactor.cli.Environment;
+import edu.ucsc.refactor.cli.Result;
+import edu.ucsc.refactor.cli.VesperCommand;
+import edu.ucsc.refactor.spi.Names;
+import edu.ucsc.refactor.spi.Refactoring;
+import edu.ucsc.refactor.spi.Smell;
+import io.airlift.airline.Command;
+
+import java.util.List;
+
+/**
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+@Command(name = "deduplicate", description = "Automatically deduplicates members of the tracked source")
+public class DeduplicateCommand extends VesperCommand {
+    @Override public Result execute(Environment environment) throws Exception {
+        ensureValidState(environment);
+
+        final List<Issue> issues = environment.getCodeRefactorer().getIssues(environment.getTrackedSource());
+        if(issues.isEmpty()){
+            return environment.unit();
+        }
+
+        for(Issue each : issues){
+            final Smell name = each.getName();
+            if(Names.hasAvailableResponse(name)){
+                if(Names.from(each.getName()).isSame(Refactoring.DEDUPLICATE)){
+                    commitChange(environment, ChangeRequest.forIssue(each));
+                }
+            }
+        }
+
+        if(environment.hasLoggedError()){
+            return Result.failedPackage(environment.getErrorMessage());
+        }
+
+        return environment.unit();
+    }
+}

--- a/src/edu/ucsc/refactor/AbstractConfiguration.java
+++ b/src/edu/ucsc/refactor/AbstractConfiguration.java
@@ -76,6 +76,7 @@ public abstract class AbstractConfiguration implements Configuration {
         addIssueDetector(new UnusedFields());
         addSourceChanger(new RemoveUnusedFields());
         addIssueDetector(new DuplicatedCode());
+        addSourceChanger(new DeduplicateCode());
         addSourceChanger(new ReformatSourceCode());
         addSourceChanger(new RenameMethod());
         addSourceChanger(new RenameParam());

--- a/src/edu/ucsc/refactor/AbstractConfiguration.java
+++ b/src/edu/ucsc/refactor/AbstractConfiguration.java
@@ -75,6 +75,7 @@ public abstract class AbstractConfiguration implements Configuration {
         addSourceChanger(new RemoveUnusedTypes());
         addIssueDetector(new UnusedFields());
         addSourceChanger(new RemoveUnusedFields());
+        addIssueDetector(new DuplicatedCode());
         addSourceChanger(new ReformatSourceCode());
         addSourceChanger(new RenameMethod());
         addSourceChanger(new RenameParam());

--- a/src/edu/ucsc/refactor/Source.java
+++ b/src/edu/ucsc/refactor/Source.java
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
  */
 public class Source {
-    public static final String SOURCE_FILE_PROPERTY = "kae.source_file.source_file_property";
+    public static final String SOURCE_FILE_PROPERTY = "vesper.source_file.source_file_property";
 
     private final String        contents;
     private final String        description;

--- a/src/edu/ucsc/refactor/internal/JavaRefactorer.java
+++ b/src/edu/ucsc/refactor/internal/JavaRefactorer.java
@@ -119,9 +119,10 @@ public class JavaRefactorer implements Refactorer {
 
         getValidContexts().put(code, context);
 
-
         final UnitLocator           inferredUnitLocator = getLocator(context.getSource());
-        final List<NamedLocation>   namedLocations      = inferredUnitLocator.locate(new InferredUnit(select));
+        final List<NamedLocation>   namedLocations      = inferredUnitLocator.locate(
+                new InferredUnit(select)
+        );
 
         for(NamedLocation eachNamedLocation : namedLocations){
             edit.addNode(((ProgramUnitLocation)eachNamedLocation).getNode());

--- a/src/edu/ucsc/refactor/internal/JavaRefactorer.java
+++ b/src/edu/ucsc/refactor/internal/JavaRefactorer.java
@@ -121,7 +121,7 @@ public class JavaRefactorer implements Refactorer {
 
         final UnitLocator           inferredUnitLocator = getLocator(context.getSource());
         final List<NamedLocation>   namedLocations      = inferredUnitLocator.locate(
-                new InferredUnit(select)
+                new SelectedUnit(select)
         );
 
         for(NamedLocation eachNamedLocation : namedLocations){

--- a/src/edu/ucsc/refactor/internal/SelectedUnit.java
+++ b/src/edu/ucsc/refactor/internal/SelectedUnit.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
  */
-public class InferredUnit extends AbstractProgramUnit  {
+public class SelectedUnit extends AbstractProgramUnit  {
     private static final String WILD_CARD = "*";
 
     private final SourceSelection   selection;
@@ -23,7 +23,7 @@ public class InferredUnit extends AbstractProgramUnit  {
      * Construct a new {@code InferredUnit} program unit with a Java {@code Context}
      * and a {@code SourceSelection}.
      */
-    public InferredUnit(SourceSelection selection) {
+    public SelectedUnit(SourceSelection selection) {
         super(WILD_CARD);
         this.selection  = selection;
     }

--- a/src/edu/ucsc/refactor/internal/changers/DeduplicateCode.java
+++ b/src/edu/ucsc/refactor/internal/changers/DeduplicateCode.java
@@ -1,0 +1,72 @@
+package edu.ucsc.refactor.internal.changers;
+
+import edu.ucsc.refactor.CauseOfChange;
+import edu.ucsc.refactor.Change;
+import edu.ucsc.refactor.Parameter;
+import edu.ucsc.refactor.internal.Delta;
+import edu.ucsc.refactor.internal.SourceChange;
+import edu.ucsc.refactor.spi.Names;
+import edu.ucsc.refactor.spi.Smell;
+import edu.ucsc.refactor.spi.SourceChanger;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
+import java.util.Map;
+
+/**
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class DeduplicateCode extends SourceChanger {
+
+    /**
+     * Instantiates a new {@link DeduplicateCode} object.
+     */
+    public DeduplicateCode(){
+        super();
+    }
+
+    @Override public boolean canHandle(CauseOfChange cause) {
+        return cause.getName().isSame(Smell.DUPLICATED_CODE)
+                || Names.from(Smell.DUPLICATED_CODE).isSame(cause.getName());
+    }
+
+    @Override protected Change initChanger(CauseOfChange cause, Map<String, Parameter> parameters) {
+        final SourceChange change   = new SourceChange(cause, this, parameters);
+        try {
+
+            final CompilationUnit root      = getCompilationUnit(cause);
+            final ASTRewrite      rewrite   = ASTRewrite.create(root.getAST());
+
+            change.getDeltas().add(deduplicate(root, rewrite, cause));
+
+        } catch (Throwable ex){
+            change.getErrors().add(ex.getMessage());
+        }
+
+        return change;
+    }
+
+
+    private Delta deduplicate(CompilationUnit root, ASTRewrite rewrite, CauseOfChange cause){
+
+
+        final int size          = cause.getAffectedNodes().size();
+        final int cloneNumber   = size == 0 ? size : size - 1; // minus the original declaration
+
+        if (cloneNumber == 0) {
+            throw new RuntimeException("calling deduplicate() when there are no detected clones");
+        } else if (cloneNumber == 1) {
+            // TODO
+            // One method. So let the other code call that method.
+            throw new UnsupportedOperationException();
+        } else {
+            // TODO
+            // More methods. Remove one of the methods.
+        }
+
+        return createDelta(root, rewrite);
+    }
+
+
+
+}

--- a/src/edu/ucsc/refactor/internal/changers/DeduplicateCode.java
+++ b/src/edu/ucsc/refactor/internal/changers/DeduplicateCode.java
@@ -5,12 +5,14 @@ import edu.ucsc.refactor.Change;
 import edu.ucsc.refactor.Parameter;
 import edu.ucsc.refactor.internal.Delta;
 import edu.ucsc.refactor.internal.SourceChange;
+import edu.ucsc.refactor.internal.util.AstUtil;
 import edu.ucsc.refactor.spi.Names;
 import edu.ucsc.refactor.spi.Smell;
 import edu.ucsc.refactor.spi.SourceChanger;
-import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.*;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -49,16 +51,48 @@ public class DeduplicateCode extends SourceChanger {
 
     private Delta deduplicate(CompilationUnit root, ASTRewrite rewrite, CauseOfChange cause){
 
-
-        final int size          = cause.getAffectedNodes().size();
-        final int cloneNumber   = size == 0 ? size : size - 1; // minus the original declaration
+        final List<ASTNode> nodes         = cause.getAffectedNodes();
+        final int           size          = nodes.size();
+        final int           cloneNumber   = size == 0 ? size : size - 1; // minus the original declaration
 
         if (cloneNumber == 0) {
             throw new RuntimeException("calling deduplicate() when there are no detected clones");
         } else if (cloneNumber == 1) {
-            // TODO
             // One method. So let the other code call that method.
-            throw new UnsupportedOperationException();
+            final MethodDeclaration original    = AstUtil.exactCast(MethodDeclaration.class, nodes.get(0));
+            final MethodDeclaration duplicate   = AstUtil.exactCast(MethodDeclaration.class, nodes.get(1));
+
+            // sanity check
+            final boolean sameReturn            = sameReturnType(original, duplicate);
+            if(!sameReturn) {
+                throw new RuntimeException("automatic deduplication cannot be done on methods "
+                        + "with different return types; please consider "
+                        + "manual deduplication."
+                );
+            }
+
+            final MethodDeclaration clone       = AstUtil.copySubtree(MethodDeclaration.class, root.getAST(), duplicate);
+            final AST ast = clone.getAST();
+
+            final Block block = ast.newBlock();
+
+            final MethodInvocation invocation       = ast.newMethodInvocation();
+            invocation.setName(ast.newSimpleName(original.getName().getIdentifier()));
+
+            AstUtil.copyArguments(duplicate.parameters(), invocation);
+
+            if(isVoidReturn(original)){
+                ExpressionStatement expressionStatement = ast.newExpressionStatement(invocation);
+                block.statements().add(expressionStatement);
+            } else {
+                final ReturnStatement  returnStatement  = ast.newReturnStatement();
+                returnStatement.setExpression(invocation);
+                block.statements().add(returnStatement);
+            }
+
+            clone.setBody(block);
+
+            rewrite.replace(duplicate, clone, null);
         } else {
             // TODO
             // More methods. Remove one of the methods.
@@ -67,6 +101,24 @@ public class DeduplicateCode extends SourceChanger {
         return createDelta(root, rewrite);
     }
 
+
+    private static boolean sameReturnType(MethodDeclaration a, MethodDeclaration b){
+       return a.getReturnType2().resolveBinding() == b.getReturnType2().resolveBinding();
+    }
+
+
+    private static boolean isVoidReturn(MethodDeclaration method){
+        if(method.getReturnType2().isPrimitiveType() ){
+            final PrimitiveType primitiveType = AstUtil.exactCast(
+                    PrimitiveType.class,
+                    method.getReturnType2()
+            );
+
+            return primitiveType.getPrimitiveTypeCode() == PrimitiveType.VOID;
+        }
+
+        return false;
+    }
 
 
 }

--- a/src/edu/ucsc/refactor/internal/changers/ReformatSourceCode.java
+++ b/src/edu/ucsc/refactor/internal/changers/ReformatSourceCode.java
@@ -25,7 +25,7 @@ public class ReformatSourceCode extends SourceChanger {
 
         final Change change = new SourceChange(cause, this, parameters);
         try {
-            for(ASTNode each : cause.getAffectedNodes()){
+            for(ASTNode each : cause.getAffectedNodes()){  // it should be one: the compilation unit
                 final Delta delta = reformat(each);
                 change.getDeltas().add(delta);
             }
@@ -38,15 +38,7 @@ public class ReformatSourceCode extends SourceChanger {
 
 
     private Delta reformat(ASTNode astNode) {
-
         final ASTRewrite rewrite = ASTRewrite.create(astNode.getAST());
-        final ASTNode replacement = ASTNode.copySubtree(
-                astNode.getAST(),
-                astNode
-        );
-
-        rewrite.replace(astNode, replacement, null);
-
         return createDelta(astNode, rewrite);
     }
 }

--- a/src/edu/ucsc/refactor/internal/detectors/DuplicatedCode.java
+++ b/src/edu/ucsc/refactor/internal/detectors/DuplicatedCode.java
@@ -31,10 +31,11 @@ public class DuplicatedCode extends IssueDetector  {
 
         final DetectedClones clones = visitor.getClones();
 
-        for(List<DetectedClone> pair : clones){
+        for(List<DetectedClone> candidates : clones){
             final Issue issue = createIssue();
-            issue.addNode(pair.get(0).getParseTree());
-            issue.addNode(pair.get(1).getParseTree());
+            for(DetectedClone candidate : candidates){
+                issue.addNode(candidate.getParseTree());
+            }
         }
 
     }

--- a/src/edu/ucsc/refactor/internal/detectors/DuplicatedCode.java
+++ b/src/edu/ucsc/refactor/internal/detectors/DuplicatedCode.java
@@ -15,8 +15,8 @@ import java.util.List;
  */
 public class DuplicatedCode extends IssueDetector  {
 
-    private static final String STRATEGY_NAME        = Smell.UNUSED_IMPORTS.getKey();
-    private static final String STRATEGY_DESCRIPTION = Smell.UNUSED_IMPORTS.getSummary();
+    private static final String STRATEGY_NAME        = Smell.DUPLICATED_CODE.getKey();
+    private static final String STRATEGY_DESCRIPTION = Smell.DUPLICATED_CODE.getSummary();
 
     /**
      * Instantiate a new duplicated code detector.

--- a/src/edu/ucsc/refactor/internal/detectors/DuplicatedCode.java
+++ b/src/edu/ucsc/refactor/internal/detectors/DuplicatedCode.java
@@ -1,0 +1,41 @@
+package edu.ucsc.refactor.internal.detectors;
+
+import edu.ucsc.refactor.Context;
+import edu.ucsc.refactor.Issue;
+import edu.ucsc.refactor.internal.util.DetectedClone;
+import edu.ucsc.refactor.internal.util.DetectedClones;
+import edu.ucsc.refactor.internal.visitors.DuplicateCodeVisitor;
+import edu.ucsc.refactor.spi.IssueDetector;
+import edu.ucsc.refactor.spi.Smell;
+
+import java.util.List;
+
+/**
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class DuplicatedCode extends IssueDetector  {
+
+    private static final String STRATEGY_NAME        = Smell.UNUSED_IMPORTS.getKey();
+    private static final String STRATEGY_DESCRIPTION = Smell.UNUSED_IMPORTS.getSummary();
+
+    /**
+     * Instantiate a new duplicated code detector.
+     */
+    public DuplicatedCode() {
+        super(STRATEGY_NAME, STRATEGY_DESCRIPTION);
+    }
+
+    @Override public void scanJava(Context context) {
+        final DuplicateCodeVisitor visitor = new DuplicateCodeVisitor(context.getSource());
+        context.accept(visitor);
+
+        final DetectedClones clones = visitor.getClones();
+
+        for(List<DetectedClone> pair : clones){
+            final Issue issue = createIssue();
+            issue.addNode(pair.get(0).getParseTree());
+            issue.addNode(pair.get(1).getParseTree());
+        }
+
+    }
+}

--- a/src/edu/ucsc/refactor/internal/util/AstUtil.java
+++ b/src/edu/ucsc/refactor/internal/util/AstUtil.java
@@ -366,6 +366,20 @@ public class AstUtil {
     }
 
 
+    public static boolean hasVoidReturn(MethodDeclaration method){
+        if(method.getReturnType2().isPrimitiveType() ){
+            final PrimitiveType primitiveType = AstUtil.exactCast(
+                    PrimitiveType.class,
+                    method.getReturnType2()
+            );
+
+            return primitiveType.getPrimitiveTypeCode() == PrimitiveType.VOID;
+        }
+
+        return false;
+    }
+
+
     /**
      * Get all the AST nodes connected to a given binding. e.g. Declaration of a field and all
      * references. For types, this includes also the constructor declaration. For methods also

--- a/src/edu/ucsc/refactor/internal/util/AstUtil.java
+++ b/src/edu/ucsc/refactor/internal/util/AstUtil.java
@@ -15,7 +15,6 @@ import org.eclipse.jdt.core.dom.*;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -109,6 +108,22 @@ public class AstUtil {
     }
 
 
+    public static void copyArguments(List src, MethodInvocation dst) {
+        for (Object eachObj : src) {
+            final SingleVariableDeclaration next  = (SingleVariableDeclaration) eachObj;
+            final SingleVariableDeclaration param = AstUtil.copySubtree(
+                    SingleVariableDeclaration.class,
+                    dst.getAST(),
+                    next
+            );
+
+            //noinspection unchecked
+            dst.arguments().add(param); // unchecked warning
+        }
+    }
+
+
+
     public static void syncSourceProperty(Source updatedSource, ASTNode node) {
         if (node instanceof CompilationUnit) {
             node.setProperty(Source.SOURCE_FILE_PROPERTY, updatedSource);
@@ -196,6 +211,8 @@ public class AstUtil {
 
     public static List<ASTNode> getChildren(ASTNode node) {
         final List<ASTNode> result = Lists.newArrayList();
+
+        if(node == null){ return result; }
 
         List list = node.structuralPropertiesForType();
 

--- a/src/edu/ucsc/refactor/internal/util/AstUtil.java
+++ b/src/edu/ucsc/refactor/internal/util/AstUtil.java
@@ -193,6 +193,42 @@ public class AstUtil {
         return (Locations.bothSame(nodeLocation, selection));
     }
 
+
+    public static List<ASTNode> getChildren(ASTNode node) {
+        final List<ASTNode> result = Lists.newArrayList();
+
+        List list = node.structuralPropertiesForType();
+
+        for(Object each : list){
+            final StructuralPropertyDescriptor descriptor = (StructuralPropertyDescriptor) each;
+            final Object child = node.getStructuralProperty(descriptor);
+
+            if (child instanceof List){
+                result.addAll(convert((List)child));
+            } else if (child instanceof ASTNode){
+                if(!(child instanceof Javadoc)){
+                    result.add((ASTNode)child);
+                }
+            }
+
+        }
+
+        return result;
+    }
+
+
+    private static List<ASTNode> convert(List list){
+        final List<ASTNode> result = Lists.newArrayList();
+        for(Object each : list){
+            final ASTNode node = (ASTNode) each;
+            if(!(node instanceof Javadoc)){
+                result.add(node);
+            }
+        }
+
+        return result;
+    }
+
     public static List<ASTNode> getSwitchCases(SwitchStatement node) {
         final List<ASTNode> result = Lists.newArrayList();
         for (Object element : node.statements()) {

--- a/src/edu/ucsc/refactor/internal/util/BucketElement.java
+++ b/src/edu/ucsc/refactor/internal/util/BucketElement.java
@@ -1,0 +1,60 @@
+package edu.ucsc.refactor.internal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class BucketElement implements Comparable<BucketElement> {
+    private List<DetectedClone> elements;
+    private int mass;
+
+    public BucketElement() {
+        this.elements = new ArrayList<DetectedClone>();
+        this.mass     = 0;
+    }
+
+    /**
+     * Add a detected clone.
+     *
+     * @param candidate The clone candidate to add.
+     * @param mass Mass of the ASTNode.
+     */
+    public void put(DetectedClone candidate, int mass) {
+        elements.add(candidate);
+
+        if (mass > this.mass) {
+            this.mass = mass;
+        }
+    }
+
+    /**
+     * Get the clone candidate at index.
+     *
+     * @param i Index.
+     * @return The clone candidate at the index.
+     */
+    public DetectedClone get(int i) {
+        return elements.get(i);
+    }
+
+    /**
+     * Compare BucketElement objects.
+     *
+     * @param that other element
+     * @return < 0 if this is smaller, 0 if equal and > 0 if this is lager.
+     */
+    @Override public int compareTo(BucketElement that) {
+        return this.mass - that.mass;
+    }
+
+    /**
+     * Gets the number of {@code ASTNode}s in this element.
+     *
+     * @return the number of {@code ASTNode}s in this element.
+     */
+    public int size() {
+        return elements.size();
+    }
+}

--- a/src/edu/ucsc/refactor/internal/util/DetectedClone.java
+++ b/src/edu/ucsc/refactor/internal/util/DetectedClone.java
@@ -1,0 +1,44 @@
+package edu.ucsc.refactor.internal.util;
+
+import com.google.common.base.Preconditions;
+import edu.ucsc.refactor.Source;
+import org.eclipse.jdt.core.dom.ASTNode;
+
+/**
+ * Stores information about a (candidate) clone.
+ *
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class DetectedClone {
+    final Source  source;
+    final ASTNode parseTree;
+
+    /**
+     * Create a new stored for a detected clone.
+     *
+     * @param source Source code
+     * @param parseTree parsed ASTNode
+     */
+    public DetectedClone(Source source, ASTNode parseTree){
+        this.source     = Preconditions.checkNotNull(source);
+        this.parseTree  = Preconditions.checkNotNull(parseTree);
+    }
+
+    /**
+     * Get the set the Source.
+     *
+     * @return the Source.
+     */
+    public Source getSource() {
+        return source;
+    }
+
+    /**
+     * Get the parse tree that is a clone.
+     *
+     * @return Parse tree that is a clone.
+     */
+    public ASTNode getParseTree() {
+        return parseTree;
+    }
+}

--- a/src/edu/ucsc/refactor/internal/util/DetectedClone.java
+++ b/src/edu/ucsc/refactor/internal/util/DetectedClone.java
@@ -25,7 +25,7 @@ public class DetectedClone {
     }
 
     /**
-     * Get the set the Source.
+     * Get the set Source.
      *
      * @return the Source.
      */

--- a/src/edu/ucsc/refactor/internal/util/DetectedClones.java
+++ b/src/edu/ucsc/refactor/internal/util/DetectedClones.java
@@ -1,0 +1,158 @@
+package edu.ucsc.refactor.internal.util;
+
+import com.google.common.collect.Lists;
+import org.eclipse.jdt.core.dom.ASTNode;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Stores detected clones.
+ *
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class DetectedClones implements Iterable <List<DetectedClone>> {
+
+    private final List<List<DetectedClone>> clones;
+
+    /**
+     * Stores detected clones.
+     */
+    public DetectedClones(){
+        this.clones = Lists.newArrayList();
+    }
+
+    /**
+     * Add a clone pair. If the clone pair already exists as subtree the
+     * clone of the subtree is removed.
+     *
+     * @param left First subtree
+     * @param right Second subtree
+     */
+    public void addClonePair(DetectedClone left, DetectedClone right) {
+        removeSubtreeClones(left, right);
+
+        // Add to a existing pair if left or right is already in a pair.
+        for(List<DetectedClone> pair : clones){      // dealing singleton maps
+            for(DetectedClone cloneItem : pair){
+                if (cloneItem.getParseTree().equals(left.getParseTree())) {
+                    pair.add(right);
+                    return;
+                } else if (cloneItem.getParseTree().equals(
+                        right.getParseTree())) {
+                    pair.add(left);
+                    return;
+                }
+            }
+        }
+
+        // The clone does not exists, add a new pair.
+        List<DetectedClone> clone = Lists.newArrayList();
+        clone.add(left);
+        clone.add(right);
+
+        clones.add(clone);
+    }
+
+
+    /**
+     * Get clone pairs by index.
+     *
+     * @param index Index
+     * @return Clone pairs at the index.
+     */
+    public List<DetectedClone> getItem(int index) {
+        return clones.get(index);
+    }
+
+
+    /**
+     * Check if subtree is a subtree of tree.
+     *
+     * @param tree Tree
+     * @param subtree Tree
+     * @return true if subtree is a subtree of tree.
+     */
+    private boolean isSubtree(ASTNode tree, ASTNode subtree) {
+        if (tree.equals(subtree)) {
+            return true;
+        }
+
+        final List<ASTNode> children = AstUtil.getChildren(tree);
+        for(ASTNode each : children){
+            if(isSubtree(each, subtree)){
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    @Override public Iterator<List<DetectedClone>> iterator() {
+        return clones.iterator();
+    }
+
+
+    /**
+     * Remove subtree clones of the subtree left and right.
+     *
+     * @param left Left subtree
+     * @param right Right subtree
+     */
+    private void removeSubtreeClones(DetectedClone left, DetectedClone right) {
+        for (int i = clones.size() - 1; i >= 0; i--) {
+            removeSubtreeClones(clones.get(i), left, right);
+        }
+    }
+
+    /**
+     * Remove subtree clones of the subtree.
+     *
+     * @param items Clone pair items to test.
+     * @param left Left subtree
+     * @param right Right subtree
+     */
+    private void removeSubtreeClones(List<DetectedClone> items,
+                                     DetectedClone left, DetectedClone right) {
+        DetectedClone matchLeft = null;
+        DetectedClone matchRight = null;
+
+        for (int i = items.size() - 1; i >= 0; i--) {
+            if (isSubtree(left.getParseTree(), items.get(i).getParseTree())) {
+                matchLeft = items.get(i);
+            } else if (isSubtree(right.getParseTree(),
+                    items.get(i).getParseTree())) {
+                matchRight = items.get(i);
+            }
+        }
+
+        if (matchLeft != null && matchRight != null) {
+            if (items.size() == 2) {
+                clones.remove(items);
+            } else if (items.size() > 3) {
+                /*
+                 * There are more clones (for example 4). The remove of left
+                 * and right keep the other clones.
+                 */
+                items.remove(matchLeft);
+                items.remove(matchRight);
+            } else {
+                /*
+                 * There are more clones (for example 3). Remove the left so
+                 * that the other clone stile exists.
+                 */
+                items.remove(matchLeft);
+            }
+        }
+    }
+
+    /**
+     * Get the number of clones.
+     *
+     * @return number of clones.
+     */
+    public int size() {
+        return clones.size();
+    }
+}

--- a/src/edu/ucsc/refactor/internal/util/TypeBucket.java
+++ b/src/edu/ucsc/refactor/internal/util/TypeBucket.java
@@ -1,0 +1,55 @@
+package edu.ucsc.refactor.internal.util;
+
+import java.util.HashMap;
+import java.util.TreeSet;
+
+/**
+ * Type bucket contains node types and AST nodes that match a node type.
+ *
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class TypeBucket {
+    private HashMap<Integer, BucketElement> bucket;
+
+    public TypeBucket() {
+        bucket = new HashMap<Integer, BucketElement>();
+    }
+
+    /**
+     * Add an {@code ASTNode} or parsed tree to the bucket.
+     *
+     * @param nodeType The node type of the parse tree.
+     * @param candidate The candidate clone.
+     * @param mass The mass (number of nodes or children) of the tree.
+     */
+    public void put(int nodeType, DetectedClone candidate, int mass) {
+        BucketElement element;
+
+        if (!bucket.containsKey(nodeType)) {
+            element = new BucketElement();
+
+            bucket.put(nodeType, element);
+        } else {
+            element = bucket.get(nodeType);
+        }
+
+        element.put(candidate, mass);
+    }
+
+    /**
+     * Get all the {@link BucketElement} items with more than one {@code ASTNode}s.
+     *
+     * @return The list of {@link BucketElement} with more than one Parse Tree.
+     */
+    public TreeSet<BucketElement> getDuplicates() {
+        final TreeSet<BucketElement> result = new TreeSet<BucketElement>();
+
+        for (Integer key : bucket.keySet()) {
+            if (bucket.get(key).size() > 1) {
+                result.add(bucket.get(key));
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/edu/ucsc/refactor/internal/visitors/DuplicateCodeVisitor.java
+++ b/src/edu/ucsc/refactor/internal/visitors/DuplicateCodeVisitor.java
@@ -1,0 +1,206 @@
+package edu.ucsc.refactor.internal.visitors;
+
+import edu.ucsc.refactor.Source;
+import edu.ucsc.refactor.internal.SourceVisitor;
+import edu.ucsc.refactor.internal.util.*;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
+ */
+public class DuplicateCodeVisitor extends SourceVisitor {
+    private static final int    MASS_THRESHOLD          = 10;
+    private static final float  SIMILARITY_THRESHOLD    = 0.98f;
+
+
+    final TypeBucket typeBucket;
+    final Source     code;
+
+    /**
+     * Get the hash of a method (subtree) parse tree.
+     */
+    public DuplicateCodeVisitor(Source code){
+        super(true);
+        this.code       = code;
+        this.typeBucket = new TypeBucket();
+    }
+
+    /**
+     * @return The detected clones in the base {@code Source}.
+     */
+    public DetectedClones getClones(){
+        final DetectedClones result = new DetectedClones();
+
+        final TreeSet<BucketElement> candidates = typeBucket.getDuplicates();
+
+        for(BucketElement candidate : candidates){
+            for (int i = 1; i < candidate.size(); i++) {
+                ASTNode left  = candidate.get(i - 1).getParseTree();
+                ASTNode right = candidate.get(i).getParseTree();
+
+                final TreeSimilarity similarity = new TreeSimilarity(left, right);
+                if(similarity.getSimilarity() > SIMILARITY_THRESHOLD){
+                    result.addClonePair(candidate.get(i - 1), candidate.get(i));
+                }
+
+            }
+        }
+
+
+        return result;
+    }
+
+    @Override public boolean visit(MethodDeclaration node) {
+        hashSubtrees(node);
+
+        return false;
+    }
+
+
+
+    /**
+     * Hash all the subtrees and add the hash to the hash bucket.
+     *
+     * @param tree Subtree to hash.
+     */
+    private void hashSubtrees(ASTNode tree) {
+        int mass = mass(tree);
+
+        final List<ASTNode> children = AstUtil.getChildren(tree);
+        final int childCount = children.size();
+
+        if (mass >= MASS_THRESHOLD) { // Ignores small subtrees.
+            for (int i = childCount - 1; i >= 0; i--) {
+                hashSubtrees(children.get(i));
+            }
+
+            int nodeType = tree.getNodeType();
+
+            DetectedClone candidate = new DetectedClone(code, tree);
+            typeBucket.put(nodeType, candidate, mass);
+        }
+    }
+
+
+    /**
+     * Get the tree mass. The tree mass is simply the number children the
+     * {@code current} node has.
+     *
+     * @param tree The current ASTNode
+     * @return The number of nodes (i.e., children) in the ASTNode tree.
+     */
+    private int mass(ASTNode tree) {
+        final List<ASTNode> children = AstUtil.getChildren(tree);
+        final int childCount = children.size();
+        int initialChildrenMass = childCount;
+
+        if (initialChildrenMass > 0) {
+            for (int i = childCount - 1; i >= 0; i--) {
+                initialChildrenMass += mass(children.get(i));
+            }
+        }
+
+        return initialChildrenMass;
+    }
+
+
+
+    @Override public boolean visit(SingleVariableDeclaration node) {
+        return super.visit(node);
+    }
+
+
+    static class TreeSimilarity {
+        int sharedNodes;
+        int leftTreeDifferentNodes;
+        int rightTreeDifferentNodes;
+
+        TreeSimilarity(ASTNode left, ASTNode right){
+            this.sharedNodes = 0;
+            this.leftTreeDifferentNodes = 0;
+            this.rightTreeDifferentNodes = 0;
+
+            compareTree(left, right);
+        }
+
+
+        public float getSimilarity() {
+            /*
+             * Similarity = 2 x S /  (2 x S + L + R)
+             * where:         S = number of shared nodes
+             *                L = number of different nodes in sub-tree 1
+             *                R = number of different nodes in sub-tree 2
+             *
+             * Source:         Clone Detection Using Abstract Syntax Trees
+             *
+             *                         Ira D. Baxter, Andrew Yahin, Leonardo Moura,
+             *                         Marcelo Sant’Anna, Lorraine Bier
+             */
+
+            float fS = (float)sharedNodes;
+            float fL = (float)leftTreeDifferentNodes;
+            float fR = (float)rightTreeDifferentNodes;
+
+            return (2 * fS) / (2 * fS + fL + fR);
+        }
+
+
+        private void compareTree(ASTNode left, ASTNode right) {
+            if (left == null && right == null) {
+                return;
+            }
+
+            if (left == null) {
+                leftTreeDifferentNodes += 1;
+            } else if (right == null) {
+                rightTreeDifferentNodes += 1;
+            } else if (left.getClass().getName().equals(right.getClass().getName())) {
+                sharedNodes += 1;
+            } else {
+                leftTreeDifferentNodes  += 1;
+                rightTreeDifferentNodes += 1;
+            }
+
+            compareChildren(left, right);
+        }
+
+
+        private void compareChildren(ASTNode left, ASTNode right) {
+            int leftCount = 0;
+            int rightCount = 0;
+
+
+            final List<ASTNode> leftChildren  = AstUtil.getChildren(left);
+            final List<ASTNode> rightChildren = AstUtil.getChildren(right);
+
+
+            if (left != null) {
+                leftCount = leftChildren.size();
+            }
+
+            if (right != null) {
+                rightCount = rightChildren.size();
+            }
+
+            for (int i = Math.max(leftCount, rightCount); i >= 0; i--) {
+                ASTNode leftSubtree  = null;
+                ASTNode rightSubtree = null;
+
+                if (i < leftCount) {
+                    leftSubtree = leftChildren.get(i);
+                }
+
+                if (i < rightCount) {
+                    rightSubtree = rightChildren.get(i);
+                }
+
+                compareTree(leftSubtree, rightSubtree);
+            }
+        }
+    }
+}

--- a/src/edu/ucsc/refactor/internal/visitors/DuplicateCodeVisitor.java
+++ b/src/edu/ucsc/refactor/internal/visitors/DuplicateCodeVisitor.java
@@ -22,7 +22,10 @@ public class DuplicateCodeVisitor extends SourceVisitor {
     final Source     code;
 
     /**
-     * Get the hash of a method (subtree) parse tree.
+     * Constructs a new {@code DuplicateCodeVisitor} with the actual
+     * source code as a value.
+     *
+     * @param code The {@code Source}
      */
     public DuplicateCodeVisitor(Source code){
         super(true);
@@ -64,7 +67,7 @@ public class DuplicateCodeVisitor extends SourceVisitor {
 
 
     /**
-     * Hash all the subtrees and add the hash to the hash bucket.
+     * Hash (using the node type) all the subtrees and add the value to the type bucket.
      *
      * @param tree Subtree to hash.
      */

--- a/src/edu/ucsc/refactor/internal/visitors/MethodInvocationVisitor.java
+++ b/src/edu/ucsc/refactor/internal/visitors/MethodInvocationVisitor.java
@@ -2,22 +2,47 @@ package edu.ucsc.refactor.internal.visitors;
 
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.SimpleName;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
  */
 public class MethodInvocationVisitor extends ASTVisitor {
 
-    private final Set<MethodInvocation> methodInvocations;
+    private final Set<MethodInvocation>         methodInvocations;
+    private final AtomicReference<SimpleName>   targetInvocation;
 
     /**
      * Instantiates a new {@link MethodInvocationVisitor}.
      */
     public MethodInvocationVisitor() {
-        methodInvocations = new HashSet<MethodInvocation>();
+        this(null);
+    }
+
+    /**
+     * Instantiates a new {@link MethodInvocationVisitor} with the matching method name
+     * as a value.
+     *
+     * @param invoke The method name this visitor is looking for.
+     */
+    public MethodInvocationVisitor(SimpleName invoke){
+        this(new HashSet<MethodInvocation>(), invoke);
+    }
+
+    /**
+     * Instantiates a new {@link MethodInvocationVisitor} with the data structure to store
+     * collected method invocations, and the matching method name as values.
+     *
+     * @param collector The data structure used to store the found invocations.
+     * @param invoke The method name this visitor is looking for.
+     */
+    MethodInvocationVisitor(Set<MethodInvocation> collector, SimpleName invoke){
+        this.methodInvocations = collector;
+        this.targetInvocation  = new AtomicReference<SimpleName>(invoke);
     }
 
     /**
@@ -28,11 +53,33 @@ public class MethodInvocationVisitor extends ASTVisitor {
      */
     @Override public boolean visit(MethodInvocation methodInvocation) {
         if (methodInvocation.resolveMethodBinding() != null) {
-            methodInvocations.add(methodInvocation);
+            if(isSimpleNameMatchingRequired()){
+                if(inTheClub(methodInvocation.getName(), targetInvocation.get())){
+                    methodInvocations.add(methodInvocation);
+                }
+            } else {
+                methodInvocations.add(methodInvocation);
+            }
         } else{ // unable to resolve method binding b/c we are not using Eclipse's Java Model
-            methodInvocations.add(methodInvocation);
+            if(isSimpleNameMatchingRequired()){
+                if(inTheClub(methodInvocation.getName(), targetInvocation.get())){
+                    methodInvocations.add(methodInvocation);
+                }
+            } else {
+                methodInvocations.add(methodInvocation);
+            }
         }
         return super.visit(methodInvocation);
+    }
+
+
+    private static boolean inTheClub(SimpleName traversed, SimpleName target){
+        return traversed.getIdentifier().equals(target.getIdentifier());
+    }
+
+
+    private boolean isSimpleNameMatchingRequired(){
+        return this.targetInvocation.get() != null;
     }
 
     public Set<MethodInvocation> getMethodInvocations() {

--- a/src/edu/ucsc/refactor/spi/Names.java
+++ b/src/edu/ucsc/refactor/spi/Names.java
@@ -13,6 +13,7 @@ public class Names {
 
     static {
         WARNING_RESPONSE_MAP.put(Smell.UNFORMATTED_CODE, Refactoring.REFORMAT_CODE);
+        WARNING_RESPONSE_MAP.put(Smell.DUPLICATED_CODE, Refactoring.DEDUPLICATE);
         WARNING_RESPONSE_MAP.put(Smell.UNUSED_FIELD, Refactoring.DELETE_FIELD);
         WARNING_RESPONSE_MAP.put(Smell.UNUSED_PARAMETER, Refactoring.DELETE_PARAMETER);
         WARNING_RESPONSE_MAP.put(Smell.UNUSED_METHOD, Refactoring.DELETE_METHOD);

--- a/src/edu/ucsc/refactor/spi/Refactoring.java
+++ b/src/edu/ucsc/refactor/spi/Refactoring.java
@@ -10,6 +10,7 @@ import java.util.NoSuchElementException;
  */
 public enum Refactoring implements Name {
     REFORMAT_CODE("Reformat Code", "Vesper will automatically reformat a selected code block"),
+    DEDUPLICATE("Deduplicate", "Vesper will automatically deduplicate existing code"),
     DELETE_TYPE("Delete Type", "Vesper will delete a selected type declaration"),
     DELETE_METHOD("Delete Method", "Vesper will delete a selected method"),
     DELETE_PARAMETER("Delete Parameter", "Vesper will delete the selected method parameter"),

--- a/src/edu/ucsc/refactor/spi/Smell.java
+++ b/src/edu/ucsc/refactor/spi/Smell.java
@@ -11,6 +11,7 @@ import java.util.*;
  * @author hsanchez@cs.ucsc.edu (Huascar A. Sanchez)
  */
 public enum Smell implements Name {
+    DUPLICATED_CODE("Duplicate code", "Vesper has detected one or more duplicated declarations!"),
     UNFORMATTED_CODE("Unformatted code", "Vesper has detected unformatted code!"),
     UNUSED_TYPE("Unused type", "Vesper has detected one or more unused type declarations!"),
     UNUSED_METHOD("Unused method", "Vesper has detected one or more unused methods!"),

--- a/test/edu/ucsc/refactor/internal/InternalUtil.java
+++ b/test/edu/ucsc/refactor/internal/InternalUtil.java
@@ -82,6 +82,7 @@ public class InternalUtil {
                         .append("\tvoid boom(){ System.out.println(1); }\n")
                         .append("\tvoid baam(){ System.out.println(1); }\n")
                         .append("\tvoid beem(){ System.out.println(1); }\n")
+                        .append("\tvoid buum(){ baam(); }\n")
                         .append("}")
         );
     }

--- a/test/edu/ucsc/refactor/internal/InternalUtil.java
+++ b/test/edu/ucsc/refactor/internal/InternalUtil.java
@@ -80,8 +80,8 @@ public class InternalUtil {
                 new StringBuilder("class Name {\n")
                         .append("\t/** {@link Name#boom(String)} **/")
                         .append("\tvoid boom(){ System.out.println(1); }\n")
-//                        .append("\t/** {@link Name#baam(String)} **/")
                         .append("\tvoid baam(){ System.out.println(1); }\n")
+                        .append("\tvoid beem(){ System.out.println(1); }\n")
                         .append("}")
         );
     }

--- a/test/edu/ucsc/refactor/internal/InternalUtil.java
+++ b/test/edu/ucsc/refactor/internal/InternalUtil.java
@@ -73,6 +73,20 @@ public class InternalUtil {
         );
     }
 
+
+    public static Source createSourceWithDuplicatedMethods(){
+        return createSource(
+                "Name.java",
+                new StringBuilder("class Name {\n")
+                        .append("\t/** {@link Name#boom(String)} **/")
+                        .append("\tvoid boom(){ System.out.println(1); }\n")
+//                        .append("\t/** {@link Name#baam(String)} **/")
+                        .append("\tvoid baam(){ System.out.println(1); }\n")
+                        .append("}")
+        );
+    }
+
+
     public static Source createSourceNoIssues(){
         return createSource(
                 "Name.java",

--- a/test/edu/ucsc/refactor/internal/changers/ChangersTest.java
+++ b/test/edu/ucsc/refactor/internal/changers/ChangersTest.java
@@ -286,6 +286,43 @@ public class ChangersTest {
     }
 
 
+    @Test public void testRemoveSelectedRegion(){
+        final Source  code    = InternalUtil.createGeneralSource();
+        final Context context = new Context(code);
+
+        parser.parseJava(context);
+
+        final ProgramUnitLocator  locator   = new ProgramUnitLocator(context);
+        final SourceSelection     selection = new SourceSelection(SourceLocation.createLocation(code, code.getContents(), 88, 281));
+        final List<NamedLocation> locations = locator.locate(new InferredUnit(selection));
+
+        final RemoveCodeRegion remove = new RemoveCodeRegion();
+        final SingleEdit       edit   = SingleEdit.deleteRegion(selection);
+
+
+        assertThat(locations.isEmpty(), is(false));
+
+        for(NamedLocation eachLocation : locations){
+            final ProgramUnitLocation target  = (ProgramUnitLocation)eachLocation;
+            edit.addNode(target.getNode());
+        }
+
+        final Change  change  = remove.createChange(edit, Maps.<String, Parameter>newHashMap());
+        assertThat(change.isValid(), is(true));
+    }
+
+
+    @Test public void testTryRemovingInvalidSelectedRegion(){
+        final Source  code    = InternalUtil.createGeneralSource();
+        final Context context = new Context(code);
+
+        parser.parseJava(context);
+
+        final ProgramUnitLocator  locator   = new ProgramUnitLocator(context);
+        final SourceSelection     selection = new SourceSelection(SourceLocation.createLocation(code, code.getContents(), 88, 275));
+        final List<NamedLocation> locations = locator.locate(new InferredUnit(selection));
+        assertThat(locations.isEmpty(), is(true)); // it's empty since this is an invalid selection
+    }
 
 
     @After public void tearDown() throws Exception {

--- a/test/edu/ucsc/refactor/internal/changers/ChangersTest.java
+++ b/test/edu/ucsc/refactor/internal/changers/ChangersTest.java
@@ -4,10 +4,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import edu.ucsc.refactor.*;
 import edu.ucsc.refactor.internal.*;
-import edu.ucsc.refactor.internal.detectors.UnusedFields;
-import edu.ucsc.refactor.internal.detectors.UnusedMethods;
-import edu.ucsc.refactor.internal.detectors.UnusedParameters;
-import edu.ucsc.refactor.internal.detectors.UnusedTypes;
+import edu.ucsc.refactor.internal.detectors.*;
 import edu.ucsc.refactor.internal.util.AstUtil;
 import edu.ucsc.refactor.spi.JavaParser;
 import edu.ucsc.refactor.util.Locations;
@@ -264,6 +261,31 @@ public class ChangersTest {
         }
 
     }
+
+
+    @Test public void testRemoveDuplicatedMethods(){
+        final Context context = new Context(
+                InternalUtil.createSourceWithDuplicatedMethods()
+        );
+
+        parser.parseJava(context);
+
+        final DuplicatedCode detector = new DuplicatedCode();
+        final Set<Issue>        issues   = detector.detectIssues(context);
+
+        assertThat(issues.size(), is(1));
+
+
+        final DeduplicateCode remove = new DeduplicateCode();
+        for(Issue each : issues){
+            Change change = remove.createChange(each, Maps.<String, Parameter>newHashMap());
+            assertNotNull(change);
+            assertThat(change.isValid(), is(true));
+        }
+
+    }
+
+
 
 
     @After public void tearDown() throws Exception {

--- a/test/edu/ucsc/refactor/internal/changers/ChangersTest.java
+++ b/test/edu/ucsc/refactor/internal/changers/ChangersTest.java
@@ -294,7 +294,7 @@ public class ChangersTest {
 
         final ProgramUnitLocator  locator   = new ProgramUnitLocator(context);
         final SourceSelection     selection = new SourceSelection(SourceLocation.createLocation(code, code.getContents(), 88, 281));
-        final List<NamedLocation> locations = locator.locate(new InferredUnit(selection));
+        final List<NamedLocation> locations = locator.locate(new SelectedUnit(selection));
 
         final RemoveCodeRegion remove = new RemoveCodeRegion();
         final SingleEdit       edit   = SingleEdit.deleteRegion(selection);
@@ -320,7 +320,7 @@ public class ChangersTest {
 
         final ProgramUnitLocator  locator   = new ProgramUnitLocator(context);
         final SourceSelection     selection = new SourceSelection(SourceLocation.createLocation(code, code.getContents(), 88, 275));
-        final List<NamedLocation> locations = locator.locate(new InferredUnit(selection));
+        final List<NamedLocation> locations = locator.locate(new SelectedUnit(selection));
         assertThat(locations.isEmpty(), is(true)); // it's empty since this is an invalid selection
     }
 

--- a/test/edu/ucsc/refactor/internal/detectors/DetectorsTest.java
+++ b/test/edu/ucsc/refactor/internal/detectors/DetectorsTest.java
@@ -4,6 +4,7 @@ import edu.ucsc.refactor.Context;
 import edu.ucsc.refactor.Issue;
 import edu.ucsc.refactor.internal.EclipseJavaParser;
 import edu.ucsc.refactor.internal.InternalUtil;
+import edu.ucsc.refactor.internal.visitors.DuplicateCodeVisitor;
 import edu.ucsc.refactor.spi.JavaParser;
 import org.junit.After;
 import org.junit.Before;
@@ -178,6 +179,22 @@ public class DetectorsTest {
 
         assertThat(issues.size(), is(0));
     }
+
+
+    @Test public void testDuplicatedMethods(){
+        final Context context = new Context(
+                InternalUtil.createSourceWithDuplicatedMethods()
+        );
+
+        parser.parseJava(context);
+
+        final DuplicatedCode    detector = new DuplicatedCode();
+        final Set<Issue>        issues   = detector.detectIssues(context);
+
+        assertThat(issues.size(), is(1));
+    }
+
+
 
     @After public void tearDown() throws Exception {
         parser  = null;


### PR DESCRIPTION
In the spirit of what de-duplication is in Data curation, it seems that my changes were enough to address a basic de-duplication implementation: if method duplicates are found, then first: rename all the invocations of the duplicate methods using the name of the original method declaration. Second: delete the duplicate method declarations from the AST. 

This will close Issue #11 and Issue #12

@bdettmer (of course, once you have time), please review the pull request. By reviewing the pull request you would learn how the AST was updated in response to de-duplication calls. Also, you would see in the Pull Request how the CLI was updated to support the De-duplication command.  
